### PR TITLE
Use more accurate `cabal-version: >= 1.10`

### DIFF
--- a/pcre-heavy.cabal
+++ b/pcre-heavy.cabal
@@ -19,7 +19,7 @@ maintainer:      greg@unrelenting.technology
 license:         PublicDomain
 license-file:    UNLICENSE
 build-type:      Simple
-cabal-version:   >= 1.18
+cabal-version:   >= 1.10
 extra-source-files:
     README.md
 tested-with:


### PR DESCRIPTION
The previous `>= 1.18` constraint made no sense as this doesn't
unlock any used new Cabal features, while breaking compilation for
older GHCs:

![snap](https://cloud.githubusercontent.com/assets/285533/9428735/9e88794e-49b8-11e5-9f2c-28dc099fd47b.png)

```
Resolving dependencies...
Failed to install pcre-heavy-0.2.3
Build log ( /tmp/extra53361987086/.cabal-sandbox/logs/pcre-heavy-0.2.3.log ):
xcabal: Error: some packages failed to install:
pcre-heavy-0.2.3 failed during the configure step. The exception was:
user error (The package 'pcre-heavy' requires Cabal library version -any &&
>=1.18 but no suitable version is installed.)
```
